### PR TITLE
fix(syncthing): netpol CGNAT range

### DIFF
--- a/k8s/workloads/home/syncthing/app/networkpolicy.yaml
+++ b/k8s/workloads/home/syncthing/app/networkpolicy.yaml
@@ -26,7 +26,7 @@ spec:
     - toCIDRSet:
         - cidr: 10.0.0.0/8
     - toCIDRSet:
-        - cidr: 100.0.0.0/8
+        - cidr: 100.64.0.0/10
     - toCIDRSet:
         - cidr: 192.168.0.0/16
     - toEndpoints:


### PR DESCRIPTION
**Description of the change**

Tailscale uses the CGNAT range which is 100.64.0.0/10, while the incorrect 100.0.0.0/8 used here will include the public IPs.

**Benefits**

Properly securing access

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
